### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@ getCurrent	KEYWORD2
 getFPS	KEYWORD2
 getFreeRAM	KEYWORD2
 begin	KEYWORD2
-setIntRef KEYWORD2
+setIntRef	KEYWORD2
 setBacklight	KEYWORD2
 setRSense	KEYWORD2
 setRIout	KEYWORD2
@@ -17,5 +17,5 @@ printVCC	KEYWORD2
 printCurrent	KEYWORD2
 getPower	KEYWORD2
 update	KEYWORD2
-print1kdecimal  KEYWORD2
+print1kdecimal	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords